### PR TITLE
fix NPE when mPrimaryColor is null, fixes #5

### DIFF
--- a/library/src/main/java/org/michaelevans/colorart/library/ColorArt.java
+++ b/library/src/main/java/org/michaelevans/colorart/library/ColorArt.java
@@ -158,8 +158,10 @@ public class ColorArt {
 
         for (CountedColor currentContainer : sortedColors) {
             currentColor = currentContainer.getColor();
-            if (mPrimaryColor == null && isContrastingColor(currentColor, mBackgroundColor)) {
-                mPrimaryColor = currentColor;
+            if (mPrimaryColor == null) {
+                if (isContrastingColor(currentColor, mBackgroundColor)) {
+                    mPrimaryColor = currentColor;
+                }
             } else if (mSecondaryColor == null) {
                 if (!isDistinctColor(mPrimaryColor, currentColor) ||
                         !isContrastingColor(currentColor, mBackgroundColor)) {


### PR DESCRIPTION
I also compared to the iOS code where this error was not happening. Seems it snuck in while trying to optimize the if-statement.
